### PR TITLE
More features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/minio/auditproxy
+module github.com/harshavardhana/auditproxy
 
 go 1.15
 


### PR DESCRIPTION
- Add port option to bind
- Backend server argument is an url now and we automatically calculate
if it is http or https
- Add an option to disable TLS hardening in the server side since some
old software cannot support recent TLS versions.
- Remove default values of tls-dir & ca-cert so we can simple start the
audit proxy without https mode.